### PR TITLE
Partially fix compatibility with Visual Studio 2019

### DIFF
--- a/AltServer/Connection.cpp
+++ b/AltServer/Connection.cpp
@@ -13,6 +13,7 @@
 
 #include <WinSock2.h>
 
+#include <codecvt>
 #include <filesystem>
 
 #include "DeviceManager.hpp"

--- a/ldid/ldid.cpp
+++ b/ldid/ldid.cpp
@@ -2157,7 +2157,7 @@ namespace ldid {
 		Mode mode_;
 		std::string code_;
 
-		mutable std::auto_ptr<Expression> regex_;
+		mutable std::unique_ptr<Expression> regex_;
 
 		Rule(unsigned weight, Mode mode, const std::string& code) :
 			weight_(weight),


### PR DESCRIPTION
This adds a missing `<codecvt>` include and switches switches from `auto_ptr` to `unique_ptr`.

This doesn't completely allow the project to be built with VS2019. ldid also needs to target C++17 and use `std::filesystem` instead of `std::experimental::filesystem`. I didn't include this change in the PR because I'm not sure if it'll break compilation with earlier versions of MSVC.

```diff
diff --git a/ldid/ldid.cpp b/ldid/ldid.cpp
index 3e30220..de7b61f 100755
--- a/ldid/ldid.cpp
+++ b/ldid/ldid.cpp
@@ -70,7 +70,7 @@
 
 #include <filesystem>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 #ifdef __APPLE__
 #include <CommonCrypto/CommonDigest.h>
diff --git a/ldid/ldid.vcxproj b/ldid/ldid.vcxproj
index f23c5fe..3c72e39 100755
--- a/ldid/ldid.vcxproj
+++ b/ldid/ldid.vcxproj
@@ -107,7 +107,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)..\Dependencies\dirent\include;$(ProjectDir)..\Dependencies\libimobiledevice-vs\libplist\include;$(ProjectDir)..\AltSign\Dependencies\regex\include;$(ProjectDir)..\AltSign\Dependencies\mman;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
```