### PR TITLE
Disable VCPKG autolinker on ldid

### DIFF
--- a/ldid/ldid.vcxproj
+++ b/ldid/ldid.vcxproj
@@ -97,6 +97,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgAutoLink>false</VcpkgAutoLink>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>


### PR DESCRIPTION
VCPKG's autolinker is incompatible with `lld-link`, see https://github.com/rileytestut/AltServer-Windows/issues/22#issuecomment-1074378955.