### PR TITLE
Fix duplicate entries in Windows notification icon settings

### DIFF
--- a/AltServer/AltServerApp.cpp
+++ b/AltServer/AltServerApp.cpp
@@ -375,12 +375,7 @@ AltServerApp* AltServerApp::instance()
 
 AltServerApp::AltServerApp() : _appGroupSemaphore(1)
 {
-	HRESULT result = CoCreateGuid(&_notificationIconGUID);
-	if (result != S_OK)
-	{
-		//TODO: Better error handling?
-		assert(false);
-	}
+	 CLSIDFromString(L"{96A5974D-D3A2-909A-B6BD-4FF84E7880F7}", &_notificationIconGUID);
 }
 
 AltServerApp::~AltServerApp()


### PR DESCRIPTION
Everytime launch, AltServer will create a new entry in system settings and lead to mess, because the notification GUID is random.

![image](https://user-images.githubusercontent.com/4949937/218749573-1eee9f56-e629-4c31-bc77-202f26bb77cc.png)
